### PR TITLE
Makefile: use compiler generated deps, cleanup variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,13 @@ ${BLDDIR}/stavplay_x86-64.nexe \
 ${BLDDIR}/stavplay_armv7.nexe \
 
 OBJS := $(patsubst %.cc, ${BLDDIR}/%.po, ${SOURCES})
+DEPS := $(patsubst %, %.deps, ${OBJS})
 
 
-#all: ${BLDDIR}/stavplay.pexe ${BLDDIR}/stavplay.nmf
 all: stavplay.wgt
+
+# first target is default. deps are targets. thus not first
+-include ${DEPS}
 
 ${BLDDIR}/stavplay.pexe: ${OBJS}
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -12,29 +12,31 @@ CERT ?= stav
 
 # tizen
 TIZEN_SDK_ROOT ?= ~/tizen-sdk
-TIZEN_SDK_DATA ?= ~/tizen-sdk-data
 TIZEN = ${TIZEN_SDK_ROOT}/tools/ide/bin/tizen
 
 # Pepper 42 for 2016 TVs
 NACL_SDK_ROOT ?= ~/nacl_sdk/pepper_42
 
-# Build flags
-WARNINGS := -Wno-long-long -Wall -Werror
-CXXFLAGS := -std=gnu++0x -g $(WARNINGS)
+WARNINGS = -Wno-long-long -Wall -Werror
+CXXFLAGS = -std=gnu++0x -g $(WARNINGS)
 
-# Tools
-GETOS := python $(NACL_SDK_ROOT)/tools/getos.py
-OSHELPERS = python $(NACL_SDK_ROOT)/tools/oshelpers.py
-OSNAME := $(shell $(GETOS))
-
+OSNAME := $(shell python $(NACL_SDK_ROOT)/tools/getos.py)
 PNACL_TC_PATH := $(abspath $(NACL_SDK_ROOT)/toolchain/$(OSNAME)_pnacl)
-PNACL_CC := $(PNACL_TC_PATH)/bin/pnacl-clang
-PNACL_CXX := $(PNACL_TC_PATH)/bin/pnacl-clang++
-PNACL_TRANSLATE := $(PNACL_TC_PATH)/bin/pnacl-translate
-PNACL_FINALIZE := $(PNACL_TC_PATH)/bin/pnacl-finalize
+
+PNACL_CC        = $(PNACL_TC_PATH)/bin/pnacl-clang
+PNACL_CXX       = $(PNACL_TC_PATH)/bin/pnacl-clang++
+PNACL_TRANSLATE = $(PNACL_TC_PATH)/bin/pnacl-translate
+PNACL_FINALIZE  = $(PNACL_TC_PATH)/bin/pnacl-finalize
+
 CXXFLAGS += -I$(NACL_SDK_ROOT)/include -I third/include
-LDFLAGS := -L$(NACL_SDK_ROOT)/lib/pnacl/Release -L third/lib
-LIBS := -lpthread -lavformat -lavcodec -lswresample -lbz2 -lavutil -lm -lc++ -lssl -lcrypto -lz -lnacl_player -lnacl_io -lppapi -lppapi_cpp
+LDFLAGS = -L$(NACL_SDK_ROOT)/lib/pnacl/Release -L third/lib
+
+LIBS = \
+ -lavformat -lavcodec -lavutil -lswresample \
+ -lssl -lcrypto \
+ -lbz2 -lz \
+ -lpthread -lm -lc++ \
+ -lnacl_player -lnacl_io -lppapi -lppapi_cpp
 
 SOURCES = \
 src/convert_codecs.cc \


### PR DESCRIPTION
I don't have the tizen and nacl SDKs installed, so I haven't tested this at all. You should probably test it before considering merging it :)

A sample test to make sure the dependencies are working:
1. do a build
2. touch src/rtsp_player_controller.h
3. do a build, check that player_provider.cc and rtsp_player_controller.cc are the only c++ files re-compiled (all the linking and translation steps should happen after that of course)
