### PR TITLE
Audio level calculation modified to decibel

### DIFF
--- a/src/rtsp_player_controller.cc
+++ b/src/rtsp_player_controller.cc
@@ -512,7 +512,7 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 	}
 
 	rms = (float)sqrt(sum / (nb_samples));
-    rms = 20 * log(rms) * 0.4343; // Multiplying by 0.4343 for base 10 conversion
+	rms = 20 * log(rms) * 0.4343; // Multiplying by 0.4343 for base 10 conversion
 	audio_rms_ = (audio_rms_ + rms) / 2.0; //Average RMS.
 
 	TimeTicks ts_now = ToTimeTicks(input_frame->best_effort_timestamp, time_base);

--- a/src/rtsp_player_controller.cc
+++ b/src/rtsp_player_controller.cc
@@ -489,7 +489,7 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 
 		for (int i = 0; i < nb_samples; i++) {
 			sample = (char)buff16[i];
-			sample = sample / 128.0; //Normalized to (+/- 1.0)
+			//sample = sample / 128.0; //Normalized to (+/- 1.0)
 			sum += (sample * sample);
 		}
 		break;
@@ -500,7 +500,7 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 
 		for (int i = 0; i < nb_samples; i++) {
 			sample = (short)(((short)buff16[(i*2) + 1] << 8) | (short)buff16[i*2]);
-			sample = sample / 32768.0; //Normalized to (+/- 1.0)
+			//sample = sample / 32768.0; //Normalized to (+/- 1.0)
 			sum += (sample * sample);
 		}
 		break;
@@ -512,6 +512,7 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 	}
 
 	rms = (float)sqrt(sum / (nb_samples));
+    rms = 20 * log(rms) * 0.4343; // Multiplying by 0.4343 for base 10 conversion
 	audio_rms_ = (audio_rms_ + rms) / 2.0; //Average RMS.
 
 	TimeTicks ts_now = ToTimeTicks(input_frame->best_effort_timestamp, time_base);

--- a/src/rtsp_player_controller.cc
+++ b/src/rtsp_player_controller.cc
@@ -489,9 +489,7 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 
 		for (int i = 0; i < nb_samples; i++) {
 			sample = (char)buff16[i];
-			//sample = sample / 128.0; //Normalized to (+/- 1.0)
-			//sum += (sample * sample);			
-			sample = (sample < 0)? -sample : sample; //abs
+			sample = fabs(sample);
 			sum += sample;
 		}
 		break;
@@ -502,9 +500,7 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 
 		for (int i = 0; i < nb_samples; i++) {
 			sample = (short)(((short)buff16[(i*2) + 1] << 8) | (short)buff16[i*2]);
-			//sample = sample / 32768.0; //Normalized to (+/- 1.0)
-			//sum += (sample * sample);
-			sample = (sample < 0)? -sample : sample; //abs
+			sample = fabs(sample);
 			sum += sample;
 		}
 		break;

--- a/src/rtsp_player_controller.cc
+++ b/src/rtsp_player_controller.cc
@@ -403,7 +403,7 @@ void RTSPPlayerController::StartParsing(int32_t) {
 
 	//Audio Level update
 	prev_audio_ts_ = 0;
-	audio_rms_ = 0;
+	audio_level_ = 0;
 	is_parsing_finished_ = false;
 	is_mute_ = false;
 
@@ -478,7 +478,7 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 	uint8_t *buff16 = *input_frame->extended_data;
 	int nb_samples = input_frame->nb_samples;
 	int bytes_per_sample = av_get_bytes_per_sample(format);
-	float sum = 0,rms=0,sample;
+	float sum = 0,decibel=0,sample;
 
 	if (audio_level_cb_frequency_ <= 0.0)  //user expects no audio-updates
 		return;
@@ -512,13 +512,13 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 	}
 
 	//rms = (float)sqrt(sum / (nb_samples));
-	rms = 20 * log(sum / nb_samples) * 0.4343; // Multiplying by 0.4343 for base 10 conversion
-	audio_rms_ = (audio_rms_ + rms) / 2.0; //Average RMS.
+	decibel = 20 * log(sum / nb_samples) * 0.4343; // Multiplying by 0.4343 for base 10 conversion
+	audio_level_ = (audio_level_ + decibel) / 2.0; //Average Decibel.
 
 	TimeTicks ts_now = ToTimeTicks(input_frame->best_effort_timestamp, time_base);
 	if ((ts_now - prev_audio_ts_) > audio_level_cb_frequency_) {
 		prev_audio_ts_ = ts_now;
-		message_sender_->SetAudioLevel((double)audio_rms_);
+		message_sender_->SetAudioLevel((double)audio_level_);
 	}
 
 }

--- a/src/rtsp_player_controller.cc
+++ b/src/rtsp_player_controller.cc
@@ -490,7 +490,9 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 		for (int i = 0; i < nb_samples; i++) {
 			sample = (char)buff16[i];
 			//sample = sample / 128.0; //Normalized to (+/- 1.0)
-			sum += (sample * sample);
+			//sum += (sample * sample);			
+			sample = (sample < 0)? -sample : sample; //abs
+			sum += sample;
 		}
 		break;
 	  }
@@ -501,7 +503,9 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 		for (int i = 0; i < nb_samples; i++) {
 			sample = (short)(((short)buff16[(i*2) + 1] << 8) | (short)buff16[i*2]);
 			//sample = sample / 32768.0; //Normalized to (+/- 1.0)
-			sum += (sample * sample);
+			//sum += (sample * sample);
+			sample = (sample < 0)? -sample : sample; //abs
+			sum += sample;
 		}
 		break;
 	  }
@@ -511,8 +515,8 @@ void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFor
 		break;
 	}
 
-	rms = (float)sqrt(sum / (nb_samples));
-	rms = 20 * log(rms) * 0.4343; // Multiplying by 0.4343 for base 10 conversion
+	//rms = (float)sqrt(sum / (nb_samples));
+	rms = 20 * log(sum / nb_samples) * 0.4343; // Multiplying by 0.4343 for base 10 conversion
 	audio_rms_ = (audio_rms_ + rms) / 2.0; //Average RMS.
 
 	TimeTicks ts_now = ToTimeTicks(input_frame->best_effort_timestamp, time_base);

--- a/src/rtsp_player_controller.h
+++ b/src/rtsp_player_controller.h
@@ -139,7 +139,7 @@ class RTSPPlayerController : public PlayerController,
 		Samsung::NaClPlayer::TimeTicks timestamp_;
 		bool is_parsing_finished_;
 		bool is_mute_;
-		float audio_rms_;
+		float audio_level_;
 		double prev_audio_ts_;
 		double audio_level_cb_frequency_;
 };


### PR DESCRIPTION
Added decibel notation for better scale.
 dB = 20 \* log (average (16-bit PCM samples));    {Range: 1 < dB < 96.33}
Please review.
Reference link - https://en.wikipedia.org/wiki/Audio_bit_depth
@protonpopsicle 
