### PR TITLE
Handling AAC input without transcoding

### DIFF
--- a/src/rtsp_player_controller.cc
+++ b/src/rtsp_player_controller.cc
@@ -137,8 +137,8 @@ void RTSPPlayerController::UpdateAudioConfig() {
 		audio_config_.codec_type = Samsung::NaClPlayer::AUDIOCODEC_TYPE_AAC;
 		audio_config_.codec_profile = ConvertAACAudioCodecProfile(s->codecpar->profile);// Method
 		audio_config_.channel_layout =  ConvertChannelLayout(s->codecpar->channel_layout, s->codecpar->channels); //Method
-		audio_config_.sample_format = ConvertSampleFormat(s->codec->sample_fmt);
-		audio_config_.bits_per_channel = av_get_bytes_per_sample(s->codec->sample_fmt) * 8 / s->codecpar->channels;
+		audio_config_.sample_format = ConvertSampleFormat((AVSampleFormat)s->codecpar->format);
+		audio_config_.bits_per_channel = s->codecpar->bits_per_raw_sample / s->codecpar->channels;
 		audio_config_.samples_per_second = s->codecpar->sample_rate ;
 	}
 	else{
@@ -523,7 +523,6 @@ void RTSPPlayerController::StartParsing(int32_t) {
 void RTSPPlayerController::calculateAudioLevel(AVFrame* input_frame, AVSampleFormat format, AVRational time_base) {
 	uint8_t *buff16 = *input_frame->extended_data;
 	int nb_samples = input_frame->nb_samples;
-	int bytes_per_sample = av_get_bytes_per_sample(format);
 	float sum = 0,decibel=0,sample;
 
 	if (audio_level_cb_frequency_ <= 0.0)  //user expects no audio-updates
@@ -589,7 +588,7 @@ std::unique_ptr<ElementaryStreamPacket> RTSPPlayerController::MakeESPacketFromAV
 	int ret = 0;
 	int data_present = 0;
 	AVFrame *input_frame = NULL;
-	uint8_t **converted_input_samples = NULL;
+
 	init_input_frame(&input_frame);
 	ret = decode(in_codec_ctx, input_frame, &data_present, input_packet);
 	if (ret < 0) {

--- a/src/rtsp_player_controller.h
+++ b/src/rtsp_player_controller.h
@@ -104,7 +104,8 @@ class RTSPPlayerController : public PlayerController,
 		std::unique_ptr<ElementaryStreamPacket> MakeESPacketFromAVPacketTranscode(
 		    AVPacket* input_packet, AVAudioFifo *fifo, AVCodecContext* in_codec_ctx,
 		    AVCodecContext* out_codec_ctx, SwrContext* resample_context);
-
+		std::unique_ptr<ElementaryStreamPacket> MakeESPacketFromAVPacketDecode(
+			AVPacket* input_packet, AVCodecContext* in_codec_ctx, bool);
 		void StartParsing(int32_t);
 		void calculateAudioLevel(AVFrame *, AVSampleFormat, AVRational);
 
@@ -143,6 +144,7 @@ class RTSPPlayerController : public PlayerController,
 		float audio_level_;
 		double prev_audio_ts_;
 		double audio_level_cb_frequency_;
+		bool is_transcode;
 };
 
 #endif

--- a/src/transcode_utils.h
+++ b/src/transcode_utils.h
@@ -374,7 +374,7 @@ static int init_transcoder(AVCodecParameters *codecpar, AVCodecContext** in_ctx,
 	LOG_INFO("IN channel_layout: %s", in_layout_str);
 	LOG_INFO("IN channels: %d", in_codec_ctx->channels);
 	LOG_INFO("IN bit_rate: %d", in_codec_ctx->bit_rate);
-	LOG_INFO("IN bits_per_channel: %d", in_codec_ctx->bit_rate / in_codec_ctx->sample_rate);
+	LOG_INFO("IN bits_per_channel: %d", codecpar->bits_per_raw_sample / in_codec_ctx->channels);
 
 	ret = avcodec_open2(in_codec_ctx, in_codec, NULL);
 	if (ret < 0) {

--- a/src/transcode_utils.h
+++ b/src/transcode_utils.h
@@ -394,10 +394,10 @@ static int init_transcoder(AVCodecParameters *codecpar, AVCodecContext** in_ctx,
 	out_codec_ctx = avcodec_alloc_context3(out_codec);
 	out_codec_ctx->profile        = FF_PROFILE_AAC_LOW;
 	out_codec_ctx->channels       = 1;
-	out_codec_ctx->sample_rate    = 8000;
+	out_codec_ctx->sample_rate    = in_codec_ctx->sample_rate ;
 	out_codec_ctx->channel_layout = av_get_default_channel_layout(out_codec_ctx->channels);
 	out_codec_ctx->sample_fmt     = out_codec->sample_fmts[0];
-	out_codec_ctx->bit_rate       = 48000;
+	out_codec_ctx->bit_rate       = in_codec_ctx->bit_rate;
 
 	char out_layout_str[16];
 	av_get_channel_layout_string(out_layout_str, sizeof(out_layout_str), -1,


### PR DESCRIPTION
Added support for AAC playback without transcoding. 
Audio level handled.
Limitation:
- Unmute does not happen on BT connected Speaker but happens on Emulator. (If we are not able to fix this then the only option is switch back to transcoding always).
- Tested with mock Arlo input (rtsp) stream and not with actual Alro Camera.

@protonpopsicle - kindly review
